### PR TITLE
fix: anthropic key validation in setup

### DIFF
--- a/setup-tiger-eon.sh
+++ b/setup-tiger-eon.sh
@@ -122,13 +122,15 @@ validate_anthropic_token() {
     log_info "Validating Anthropic API key..."
 
     local response
-    response=$(curl -s -H "Authorization: Bearer $token" \
+    response=$(
+        curl -s \
+        -H "x-api-key: $token" \
+        -H "anthropic-version: 2023-06-01" \
         -H "Content-Type: application/json" \
-        "https://api.anthropic.com/v1/messages" \
-        -d '{"model":"claude-sonnet-4-20250514","max_tokens":1,"messages":[{"role":"user","content":"test"}]}' \
-        | grep -o '"error"' || echo "ok")
+        "https://api.anthropic.com/v1/models"
+    )
 
-    if [[ "$response" == '"error"' ]]; then
+    if echo "$response" | grep -q '"type":"error"'; then
         log_error "Invalid Anthropic API key"
         return 1
     fi
@@ -198,7 +200,7 @@ create_slack_app() {
 
     # Interactive Slack App Setup
     echo "Creating $app_type Slack App:"
-    
+
 
     open_browser "https://api.slack.com/apps/"
 


### PR DESCRIPTION
PR fixes the anthropic key validation, which was broken in the following ways:

1. It was not passing the proper authorization headers per [the docs](https://docs.claude.com/en/api/overview#authentication)
2. It was not passing `anthropic-version` header
3. The check for if an error was returned didn't work since it assumed that the string `"error"` would only appear once for failure (as we check string equality `response == '"error"'`, where the endpoint was returning:
    ```
    {"type":"error","error":{"type":"authentication_error","message":"Invalid bearer token"},"request_id":"req_011CTf5vQp3A5z6mMdpUPaBy"}
    ```
    and so the grep was giving us:
    ```
    "error"
    "error"
    ```