### PR TITLE
fix: always docker compose pull when starting services

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -31,7 +31,7 @@ fi
 
 # Start only the enabled services
 echo "Starting services: $SERVICES"
-docker compose up -d $SERVICES
+docker compose pull && docker compose up -d $SERVICES
 
 echo "Services started successfully!"
 echo "Use 'docker compose ps' to see running services"


### PR DESCRIPTION
PR makes it so that the start.sh script always does `docker compose pull` before we start the images, to try to ensure that we hav the latest version of a given image. This should help avoid the situation where a user had previously pulled like `timescaledb/timescaledb-ha:pg17` a long time ago and so have an outdated version of timescale extension on a fresh start of this repo.