### PR TITLE
feat: offer to use tiger free tier for db in setup script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,6 @@ services:
 
   tiger-agent:
     image: ghcr.io/timescale/tiger-agent:0.0.2
-    depends_on:
-      db:
-        condition: service_healthy
     environment: &env_vars
       PGHOST: ${PGHOST}
       PGPORT: ${PGPORT}
@@ -50,8 +47,6 @@ services:
 
   tiger-slack-ingest:
     image: ghcr.io/timescale/tiger-slack-ingest:0.1.3
-    depends_on:
-      - db
     environment:
       <<: *env_vars
       SLACK_APP_TOKEN: ${SLACK_INGEST_APP_TOKEN}
@@ -59,8 +54,6 @@ services:
 
   tiger-slack-mcp-server:
     image: ghcr.io/timescale/tiger-slack-mcp:0.1.2
-    depends_on:
-      - db
     environment:
       <<: *env_vars
       PORT: 80
@@ -71,8 +64,6 @@ services:
 
   tiger-gh-mcp-server:
     image: ghcr.io/timescale/tiger-github-mcp:0.1.1
-    depends_on:
-      - db
     environment:
       PORT: 80
       GITHUB_ORG: ${GITHUB_ORG}


### PR DESCRIPTION
PR adds to the setup asking the user if they want to use tiger cloud free tier and if they answer yes, then we create the database using the [tiger-cli](https://github.com/timescale/tiger-cli) tool, set the appropriate values in the `.env` file, and then also wait for the database to be ready before we continue to the `start_services` phase of setup.

`start.sh` was also modified such that if `PGHOST != 'db'`, then we assume the user is using a database external to the docker network and so we don't start the `db` service.