### PR TITLE
[CHORE] Fix db persistence between docker container restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,4 +89,4 @@ services:
       - linear
     pull_policy: always
 volumes:
-  postgres_data:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:${PGPORT}"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - db_data:/home/postgres/pgdata/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${PGUSER} -d ${PGDATABASE}"]
       interval: 5s


### PR DESCRIPTION
## Why
It is unfortunate to lose your db when you restart a container

## How
Fix the volume to mount the proper container directory - `/var/lib/postgresql/data` should be `/home/postgres/pgdata/data`

## Related
https://github.com/timescale/tiger-slack/pull/70
https://github.com/timescale/tiger-eon-internal/pull/53